### PR TITLE
Fix creation of 'A' records with a single IP

### DIFF
--- a/lib/dynect_rest/resource.rb
+++ b/lib/dynect_rest/resource.rb
@@ -117,7 +117,7 @@ class DynectRest
     def method_missing(method_symbol, *args, &block)
       method_string = method_symbol.to_s
       if (args.length > 0 && method_string !~ /=$/)
-        @rdata[method_string] = *args
+        @rdata[method_string] = args.length == 1 ? args[0] : args
         self
       elsif @rdata.has_key?(method_string)
         @rdata[method_string]


### PR DESCRIPTION
A records were breaking when a single IP address was assigned. It seems that the dynect rest API doesn't accept an array of addresses as input when there is only 1 item in that array.

Not sure if this ever worked, but this patch at least fixes the problem for me.
