### PR TITLE
Unable to Delete a record

### DIFF
--- a/lib/dynect_rest/resource.rb
+++ b/lib/dynect_rest/resource.rb
@@ -63,7 +63,7 @@ class DynectRest
       if record_id && fqdn
         raw_rr = @dynect.get("#{resource_path}/#{fqdn}/#{record_id}")
         DynectRest::Resource.new(dynect,
-                                 raw_rr["record_type"],
+                                 raw_rr["record_type"] + 'Record',
                                  raw_rr["zone"],
                                  raw_rr["fqdn"],
                                  raw_rr["record_id"],


### PR DESCRIPTION
The code to enumerate records in a zone does not compose the record_type instance variable properly when parsing the payload from the GET request

As a result, the resource URL for a record looks something like:

/REST/CNAME/myzone.com/bob.myzone.com/1234

Rather than

/REST/CNAMERecord/myzone.com/bob.myzone.com/1234

If you call .delete on the resource, it fails with an 'unknown resource' error

This fixes that
