### PR TITLE
Adds 'Record' to all record_types

### DIFF
--- a/lib/dynect_rest/resource.rb
+++ b/lib/dynect_rest/resource.rb
@@ -53,9 +53,9 @@ class DynectRest
 
     def resource_path(full=false)
       if (full == true || full == :full) 
-        "/REST/#{@record_type}/#{@zone}"
+        "/REST/#{@record_type}Record/#{@zone}"
       else
-        "#{@record_type}/#{@zone}"
+        "#{@record_type}Record/#{@zone}"
       end
     end
 


### PR DESCRIPTION
I ran into this problem:

DynectRest::Exceptions::RequestFailed: Request failed: ERROR INVALID_REQUEST API-A - Unknown resource A (Requested URI: /REST/A/mydomain.net/somerecord.mydomain.net)

I believe this patch fixes it for all record types.
