### PR TITLE
Fix for 'find' method

### DIFF
--- a/lib/dynect_rest/resource.rb
+++ b/lib/dynect_rest/resource.rb
@@ -94,7 +94,7 @@ class DynectRest
 
     def find(fqdn, query_hash)
       results = []
-      get(fqdn).each do |rr|
+      [get(fqdn)].flatten.each do |rr|
         query_hash.each do |key, value|
           results << rr if rr[key.to_s] == value
         end


### PR DESCRIPTION
In the 'find' method, get(fqdn) is expected to return an Array, however if only one record is found it returns Dynect::Resource object (line 85-86 in resource.rb). In this case 'find' would throw a NoMethodError: undefined method `each' for DynectRest::Resource exception.

Thanks for writing this, it has been invaluable in helping me automate my infrastructure.
