### PR TITLE
Fix redirect handling

### DIFF
--- a/lib/dynect_rest.rb
+++ b/lib/dynect_rest.rb
@@ -196,6 +196,7 @@ class DynectRest
         puts "I have #{e.inspect} with #{e.http_code}"
       end
       if e.http_code == 307
+        e.response.sub!('/REST/','') if e.response =~ /^\/REST\//
         get(e.response)
       end
       e.response


### PR DESCRIPTION
Some of our interactions with Dyn cause long-running API calls. Unfortunately, dynect_rest doesn't correctly handle the 307 redirects. Instead, we get unhandled exeptions being thrown from RestClient. These two commits fix the unhandled exceptions and expose the ability to configure RestClient's max_redirects parameter.
