### PR TITLE
Dynect GSLB to_json should be consistent

### DIFF
--- a/lib/dynect_rest/gslb.rb
+++ b/lib/dynect_rest/gslb.rb
@@ -156,7 +156,7 @@ class DynectRest
     def to_json
       {
         "ttl"   => @ttl,
-        "monitor" => @monitor,
+        "monitor" => @monitor.sort,
         "region" => {
           "region_code" => @region_code,
           "serve_count" => @serve_count,


### PR DESCRIPTION
Let's be consistent in our to_json response. This allows it to be compared easily
