### PR TITLE
Propagate unhandled REST exception to caller.

### DIFF
--- a/lib/dynect_rest.rb
+++ b/lib/dynect_rest.rb
@@ -229,7 +229,8 @@ class DynectRest
         e.response.sub!(/^\/REST\//,'')
         get(e.response)
       end
-      e.response
+      # Something went wrong, so escalate to caller
+      raise DynectRest::Exceptions::RequestFailed, "Request failed: #{e.inspect}"
     end
 
     parse_response(JSON.parse(response_body || '{}'))


### PR DESCRIPTION
If the RestClient::Exception is not properly handled (like for the
redirect case) the result is most likely useless. Instead throw an
exception so the caller can react accordingly.