### PR TITLE
use json_pure to avoid compiling native extensions

### DIFF
--- a/lib/dynect_rest.rb
+++ b/lib/dynect_rest.rb
@@ -22,7 +22,7 @@ class DynectRest
   require 'dynect_rest/gslb'
   require 'dynect_rest/resource'
   require 'rest_client'
-  require 'json'
+  require 'json_pure'
 
   attr_accessor :customer_name, :user_name, :password, :rest, :zone
 


### PR DESCRIPTION
I think this might be a valid fix for https://github.com/adamhjk/dynect_rest/issues/41