### PR TITLE
Fix for GSLB monitor not taking effect.

### DIFF
--- a/lib/dynect_rest/gslb.rb
+++ b/lib/dynect_rest/gslb.rb
@@ -156,7 +156,7 @@ class DynectRest
     def to_json
       {
         "ttl"   => @ttl,
-        "monitor" => @monitor.sort,
+        "monitor" => @monitor,
         "region" => {
           "region_code" => @region_code,
           "serve_count" => @serve_count,


### PR DESCRIPTION
The "monitor" argument was being passed as a bunch of arrays due to the `.sort` call. The Dynect API was silently failing to set the monitor because of this. 

The outcome of this PR is that instead of this being sent to the Dynect API,

    [[:expected, ""], [:header, ""], [:host, "example.com"], [:interval, 1], [:path, "/up"], [:port, 80], [:protocol, "HTTP"], [:retries, 2]]

we will now send this,

    "{\"protocol\":\"HTTP\",\"interval\":1,\"retries\":2,\"port\":80,\"path\":\"/health\",\"host\":\"example.com\",\"header\":\"\",\"expected\":\"\"}"

and Dynect will correctly accept and apply the new monitor settings.